### PR TITLE
fix permit type check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dzapio/sdk",
-  "version": "2.0.16",
+  "version": "2.0.18",
   "description": "A TypeScript/JavaScript SDK for interacting with the DZap protocol, providing utilities for DeFi operations including Swaps, Bridges, and Zaps.",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/src/constants/permit.ts
+++ b/src/constants/permit.ts
@@ -1,5 +1,5 @@
 import { DZapPermitMode } from '../enums';
-import { encodePacked, keccak256 } from 'viem';
+import { encodePacked, keccak256, stringToHex } from 'viem';
 
 export const eip2612GaslessDomain = {
   name: 'DZapVerifier',
@@ -33,3 +33,5 @@ export const PermitToDZapPermitMode = {
   [PermitTypes.PermitWitnessTransferFrom]: DZapPermitMode.PERMIT2_WITNESS_TRANSFER,
   [PermitTypes.PermitBatchWitnessTransferFrom]: DZapPermitMode.BATCH_PERMIT2_WITNESS_TRANSFER,
 } as const;
+
+export const EIP2612_PERMIT_TYPEHASH = keccak256(stringToHex('Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)'));

--- a/src/dZapClient/index.ts
+++ b/src/dZapClient/index.ts
@@ -49,6 +49,7 @@ import {
   PermitMode,
   SignPermitResponse,
   TokenInfo,
+  TokenPermitData,
   TokenResponse,
   TradeBuildTxnRequest,
   TradeBuildTxnResponse,
@@ -778,7 +779,7 @@ class DZapClient {
   }: {
     chainId: number;
     sender: HexString;
-    tokens: { address: HexString; amount: string }[];
+    tokens: { address: HexString; amount: string; permit?: TokenPermitData }[];
     service: AvailableDZapServices;
     rpcUrls?: string[];
     spender?: HexString; // Optional custom spender address

--- a/src/utils/eip-2612/eip2612Permit.ts
+++ b/src/utils/eip-2612/eip2612Permit.ts
@@ -3,7 +3,8 @@ import { encodeAbiParameters, maxUint256, parseAbiParameters } from 'viem';
 import { erc20PermitAbi } from '../../artifacts/ERC20Permit';
 import { config } from '../../config';
 import { Services } from '../../constants';
-import { erc20Functions } from '../../constants/erc20';
+import { erc20Functions, erc20PermitFunctions } from '../../constants/erc20';
+import { EIP2612_PERMIT_TYPEHASH } from '../../constants/permit';
 import { DEFAULT_PERMIT_VERSION, SignatureExpiryInSecs } from '../../constants/permit2';
 import { ContractVersion, DZapPermitMode, StatusCodes, TxnStatus } from '../../enums';
 import { HexString, TokenPermitData } from '../../types';
@@ -14,6 +15,7 @@ import { multicall } from '../multicall';
 import { signTypedData } from '../signTypedData';
 
 export const eip2612DisabledChains = config.getEip2612DisabledChains();
+
 /**
  * Check if a token supports EIP-2612 permits by checking for required functions
  */
@@ -62,6 +64,11 @@ export const checkEIP2612PermitSupport = async ({
       abi: erc20PermitAbi,
       functionName: erc20Functions.name,
     },
+    {
+      address: address as HexString,
+      abi: erc20PermitAbi,
+      functionName: erc20PermitFunctions.PERMIT_TYPEHASH,
+    },
   ];
 
   const multicallResult = await multicall({
@@ -76,15 +83,25 @@ export const checkEIP2612PermitSupport = async ({
   }
 
   const results = multicallResult.data as Array<{ status: string; result: unknown }>;
-  const [domainSeparatorResult, nonceResult, versionResult, nameResult] = results;
+  const [domainSeparatorResult, nonceResult, versionResult, nameResult, permitTypeHashResult] = results;
 
-  if (domainSeparatorResult.status !== TxnStatus.success || nonceResult.status !== TxnStatus.success || nameResult.status !== TxnStatus.success) {
+  if (
+    domainSeparatorResult.status !== TxnStatus.success ||
+    nonceResult.status !== TxnStatus.success ||
+    nameResult.status !== TxnStatus.success ||
+    permitTypeHashResult.status !== TxnStatus.success
+  ) {
     return { supportsPermit: false };
   }
 
   const name = nameResult.result as string;
   const nonce = nonceResult.result as bigint;
   const version = versionResult.status === TxnStatus.success ? (versionResult.result as string) : DEFAULT_PERMIT_VERSION;
+
+  const permitTypeHash = permitTypeHashResult.result as HexString;
+  if (permitTypeHash.toLowerCase() !== EIP2612_PERMIT_TYPEHASH.toLowerCase()) {
+    return { supportsPermit: false };
+  }
 
   return {
     supportsPermit: true,

--- a/src/utils/erc20.ts
+++ b/src/utils/erc20.ts
@@ -173,11 +173,12 @@ export const getAllowance = async ({ chainId, sender, tokens, rpcUrls, multicall
           token: address,
           spender,
           amount,
+          isEIP2612PermitSupported: false,
           isDefaultApprovalMode: true,
         };
       } else {
         const permit2Address = getPermit2Address(chainId);
-        return { token: address, spender: permit2Address, amount, isDefaultApprovalMode: false };
+        return { token: address, spender: permit2Address, amount, isEIP2612PermitSupported: false, isDefaultApprovalMode: false };
       }
     }),
   );


### PR DESCRIPTION

Fix EIP-2612 fallback detection by validating canonical PERMIT_TYPEHASH to avoid DAI-style permit false positives.
Extend DZapClient.getAllowance token input type to accept per-token permit metadata.
