### PR TITLE
feat: add bundle zap actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dzapio/sdk",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "description": "A TypeScript/JavaScript SDK for interacting with the DZap protocol, providing utilities for DeFi operations including Swaps, Bridges, and Zaps.",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,7 +23,15 @@ import {
   TradeBuildTxnRequest,
   TradeQuotesRequest,
 } from '../types';
-import { ZapBuildTxnRequest, ZapPoolDetailsRequest, ZapPoolsRequest, ZapPositionsRequest, ZapQuoteRequest, ZapStatusRequest } from '../types/zap';
+import {
+  ZapBundleRequest,
+  ZapBuildTxnRequest,
+  ZapPoolDetailsRequest,
+  ZapPoolsRequest,
+  ZapPositionsRequest,
+  ZapQuoteRequest,
+  ZapStatusRequest,
+} from '../types/zap';
 import { BroadcastZapTxResponse } from '../types/zap/broadcast';
 import { invoke, invokeZap } from '../utils/axios';
 import { ZAP_ENDPOINTS } from '../zap/constants/urls';
@@ -75,6 +83,22 @@ export const fetchZapBuildTxnData = (request: ZapBuildTxnRequest, cancelToken?: 
 export const fetchZapQuote = (request: ZapQuoteRequest, cancelToken?: CancelToken) =>
   invokeZap({
     endpoint: ZAP_ENDPOINTS.quote,
+    data: request,
+    method: POST,
+    cancelToken,
+  });
+
+export const fetchZapBundleQuote = (request: ZapBundleRequest, cancelToken?: CancelToken) =>
+  invokeZap({
+    endpoint: ZAP_ENDPOINTS.bundle.quote,
+    data: request,
+    method: POST,
+    cancelToken,
+  });
+
+export const fetchZapBundleBuildTx = (request: ZapBundleRequest, cancelToken?: CancelToken) =>
+  invokeZap({
+    endpoint: ZAP_ENDPOINTS.bundle.buildTx,
     data: request,
     method: POST,
     cancelToken,

--- a/src/chains/definitions/tempo.ts
+++ b/src/chains/definitions/tempo.ts
@@ -1,6 +1,7 @@
+import type { Chain } from 'viem/chains';
 import { tempo as tempoViem } from 'viem/chains';
 
-export const tempo = tempoViem.extend({
+export const tempo: Chain = tempoViem.extend({
   feeToken: '0x20C0000000000000000000000000000000000000',
   contracts: {
     multicall3: {

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -17,7 +17,7 @@ export { pushTestnet } from './definitions/pushTestnet';
 export { stableChain } from './definitions/stable';
 export { tempo } from './definitions/tempo';
 
-export const customViemChains = [fiveIre, arthera, hyperEvm, hyperliquid, stableChain, pushTestnet, astralisTestnet, tempo];
+export const customViemChains: viemChains.Chain[] = [fiveIre, arthera, hyperEvm, hyperliquid, stableChain, pushTestnet, astralisTestnet, tempo];
 
 export const viemChainsById: Record<number, viemChains.Chain> = [...Object.values(viemChains), ...customViemChains].reduce((acc, chainData) => {
   return chainData.id

--- a/src/dZapClient/index.ts
+++ b/src/dZapClient/index.ts
@@ -14,6 +14,8 @@ import {
   fetchTokenDetails,
   fetchTradeBuildTxnData,
   fetchTradeQuotes,
+  fetchZapBundleBuildTx,
+  fetchZapBundleQuote,
   fetchZapBuildTxnData,
   fetchZapChains,
   fetchZapPoolDetails,
@@ -58,6 +60,7 @@ import {
   TradeStatusResponse,
 } from '../types';
 import {
+  ZapBundleRequest,
   ZapBuildTxnRequest,
   ZapBuildTxnResponse,
   ZapChains,
@@ -974,6 +977,38 @@ class DZapClient {
   }
 
   /**
+   * Executes a bundle of zap actions (multiple protocol interactions in sequence) as a single transaction.
+   * Use this for complex flows such as swap → bridge → zap, or multiple zap actions in one call.
+   *
+   * @param params - Configuration object for zap bundle execution
+   * @param params.request - The zap bundle request containing actions, account, recipient, and slippage
+   * @param params.signer - The wallet signer to sign and execute the transaction
+   * @param params.steps - Optional array of pre-built transaction steps (if not provided, will build from request)
+   * @returns Promise resolving to zap bundle transaction execution result
+   *
+   * @example
+   * ```typescript
+   * const result = await client.zapBundle({
+   *   request: {
+   *     actions: [{ action: 'swap', srcToken: { address: '0x...' }, srcChainId: 1, destToken: '0x...', destChainId: 1 }, ...],
+   *     account: '0x...',
+   *     recipient: '0x...',
+   *     refundee: '0x...',
+   *     slippage: 1
+   *   },
+   *   signer: walletClient
+   * });
+   * ```
+   */
+  public async zapBundle({ request, steps, signer }: { request: ZapBundleRequest; signer: WalletClient | Signer; steps?: ZapTransactionStep[] }) {
+    return await ZapTxnHandler.zapBundle({
+      request,
+      steps,
+      signer,
+    });
+  }
+
+  /**
    * Builds comprehensive transaction data for zap operations without executing them.
    * This method prepares all necessary steps, routing information, and transaction parameters
    * for complex multi-protocol interactions. The resulting data can be used with the zap method.
@@ -1038,6 +1073,37 @@ class DZapClient {
     }
     this.cancelTokenSource = Axios.CancelToken.source();
     const route: ZapQuoteResponse = (await fetchZapQuote(request, this.cancelTokenSource.token)).data;
+    return route;
+  }
+
+  /**
+   * Fetches pricing and routing for bundle operations (portfolio position actions).
+   * Use for claim fees, compound, decrease, increase, reposition.
+   *
+   * @param request - The bundle request with actions array
+   * @returns Promise resolving to zap quote (amountOut, approvalData, path)
+   */
+  public async getZapBundleQuote(request: ZapBundleRequest): Promise<ZapQuoteResponse> {
+    if (this.cancelTokenSource) {
+      this.cancelTokenSource.cancel('Cancelled due to new request');
+    }
+    this.cancelTokenSource = Axios.CancelToken.source();
+    const route: ZapQuoteResponse = (await fetchZapBundleQuote(request, this.cancelTokenSource.token)).data;
+    return route;
+  }
+
+  /**
+   * Builds transaction data for bundle operations (portfolio position actions).
+   *
+   * @param request - The bundle request with actions array
+   * @returns Promise resolving to zap build response (steps, path, approvalData)
+   */
+  public async buildZapBundleTx(request: ZapBundleRequest): Promise<ZapBuildTxnResponse> {
+    if (this.cancelTokenSource) {
+      this.cancelTokenSource.cancel('Cancelled due to new request');
+    }
+    this.cancelTokenSource = Axios.CancelToken.source();
+    const route: ZapBuildTxnResponse = (await fetchZapBundleBuildTx(request, this.cancelTokenSource.token)).data;
     return route;
   }
 

--- a/src/dZapClient/index.ts
+++ b/src/dZapClient/index.ts
@@ -968,40 +968,16 @@ class DZapClient {
    * });
    * ```
    */
-  public async zap({ request, steps, signer }: { request: ZapBuildTxnRequest; signer: WalletClient | Signer; steps?: ZapTransactionStep[] }) {
+  public async zap({
+    request,
+    steps,
+    signer,
+  }: {
+    request: ZapBuildTxnRequest | ZapBundleRequest;
+    signer: WalletClient | Signer;
+    steps?: ZapTransactionStep[];
+  }) {
     return await ZapTxnHandler.zap({
-      request,
-      steps,
-      signer,
-    });
-  }
-
-  /**
-   * Executes a bundle of zap actions (multiple protocol interactions in sequence) as a single transaction.
-   * Use this for complex flows such as harvest → deposit, or multiple zap actions in one call.
-   *
-   * @param params - Configuration object for zap bundle execution
-   * @param params.request - The zap bundle request containing actions, account, recipient, and slippage
-   * @param params.signer - The wallet signer to sign and execute the transaction
-   * @param params.steps - Optional array of pre-built transaction steps (if not provided, will build from request)
-   * @returns Promise resolving to zap bundle transaction execution result
-   *
-   * @example
-   * ```typescript
-   * const result = await client.zapBundle({
-   *   request: {
-   *     actions: [{ action: 'swap', srcToken: { address: '0x...' }, srcChainId: 1, destToken: '0x...', destChainId: 1 }, ...],
-   *     account: '0x...',
-   *     recipient: '0x...',
-   *     refundee: '0x...',
-   *     slippage: 1
-   *   },
-   *   signer: walletClient
-   * });
-   * ```
-   */
-  public async zapBundle({ request, steps, signer }: { request: ZapBundleRequest; signer: WalletClient | Signer; steps?: ZapTransactionStep[] }) {
-    return await ZapTxnHandler.zapBundle({
       request,
       steps,
       signer,

--- a/src/dZapClient/index.ts
+++ b/src/dZapClient/index.ts
@@ -978,7 +978,7 @@ class DZapClient {
 
   /**
    * Executes a bundle of zap actions (multiple protocol interactions in sequence) as a single transaction.
-   * Use this for complex flows such as swap → bridge → zap, or multiple zap actions in one call.
+   * Use this for complex flows such as harvest → deposit, or multiple zap actions in one call.
    *
    * @param params - Configuration object for zap bundle execution
    * @param params.request - The zap bundle request containing actions, account, recipient, and slippage
@@ -1077,11 +1077,12 @@ class DZapClient {
   }
 
   /**
-   * Fetches pricing and routing for bundle operations (portfolio position actions).
-   * Use for claim fees, compound, decrease, increase, reposition.
+   * Fetches quote data (pricing, routing, and approvals) for bundle operations.
+   * Bundle operations support portfolio position actions such as claim fees,
+   * harvest, decrease, increase, and reposition.
    *
-   * @param request - The bundle request with actions array
-   * @returns Promise resolving to zap quote (amountOut, approvalData, path)
+   * @param request - Bundle quote request containing the actions array
+   * @returns Promise resolving to bundle quote response (amountOut, approvalData, path)
    */
   public async getZapBundleQuote(request: ZapBundleRequest): Promise<ZapQuoteResponse> {
     if (this.cancelTokenSource) {
@@ -1093,10 +1094,11 @@ class DZapClient {
   }
 
   /**
-   * Builds transaction data for bundle operations (portfolio position actions).
+   * Builds executable transaction data for bundle operations.
+   * Use this after fetching a bundle quote.
    *
-   * @param request - The bundle request with actions array
-   * @returns Promise resolving to zap build response (steps, path, approvalData)
+   * @param request - Bundle build request containing the actions array
+   * @returns Promise resolving to bundle build response (steps, path, approvalData)
    */
   public async buildZapBundleTx(request: ZapBundleRequest): Promise<ZapBuildTxnResponse> {
     if (this.cancelTokenSource) {

--- a/src/transactionHandlers/zap.ts
+++ b/src/transactionHandlers/zap.ts
@@ -148,6 +148,13 @@ class ZapTxnHandler {
           txnHash = result.txnHash as HexString;
         }
       }
+      if (!txnHash) {
+        return {
+          status: TxnStatus.error,
+          code: StatusCodes.Error,
+          errorMsg: 'No executable steps found.',
+        };
+      }
       return {
         status: TxnStatus.success,
         code: StatusCodes.Success,

--- a/src/transactionHandlers/zap.ts
+++ b/src/transactionHandlers/zap.ts
@@ -1,9 +1,9 @@
 import { Signer } from 'ethers';
 import { WalletClient } from 'viem';
-import { fetchZapBuildTxnData } from '../api';
+import { fetchZapBuildTxnData, fetchZapBundleBuildTx } from '../api';
 import { StatusCodes, TxnStatus } from '../enums';
 import { DZapTransactionResponse, HexString } from '../types';
-import { ZapBuildTxnRequest, ZapBuildTxnResponse } from '../types/zap';
+import { ZapBuildTxnRequest, ZapBuildTxnResponse, ZapBundleRequest } from '../types/zap';
 import { ZapStep, ZapEvmTxnDetails } from '../types/zap/step';
 import { getPublicClient, isTypeSigner } from '../utils';
 import { viemChainsById } from '../chains';
@@ -136,26 +136,77 @@ class ZapTxnHandler {
           };
         }
       }
-      let txnHash: HexString | undefined;
-      for (let i = 0; i < steps.length; i++) {
-        const step = steps[i];
-        if (step.action === zapStepAction.execute) {
-          const result = await ZapTxnHandler.execute({ chainId, txnData: step.data as ZapEvmTxnDetails, signer });
-          if (result.status !== TxnStatus.success) {
-            return result;
-          }
-          txnHash = result.txnHash as HexString;
-        }
-      }
-      return {
-        status: TxnStatus.success,
-        code: StatusCodes.Success,
-        txnHash,
-      };
+      const result = this.executeZap(steps, chainId, signer);
+      return result;
     } catch (error: any) {
       console.log({ error });
       return handleViemTransactionError({ error });
     }
+  };
+
+  public static zapBundle = async ({
+    request,
+    steps,
+    signer,
+  }: {
+    request: ZapBundleRequest;
+    steps?: ZapStep[];
+    signer: Signer | WalletClient;
+  }): Promise<
+    | {
+        status: TxnStatus.success;
+        code: StatusCodes | number;
+        txnHash: HexString;
+      }
+    | DZapTransactionResponse
+  > => {
+    try {
+      const chainId = request.actions[0].srcChainId;
+
+      if (!chainId) {
+        return {
+          status: TxnStatus.error,
+          code: StatusCodes.Error,
+          errorMsg: 'Source chain ID is required.',
+        };
+      }
+      if (!steps || steps.length === 0) {
+        const route: ZapBuildTxnResponse = (await fetchZapBundleBuildTx(request)).data;
+        steps = route.steps;
+        if (!steps || steps.length === 0) {
+          return {
+            status: TxnStatus.error,
+            code: StatusCodes.FunctionNotFound,
+            errorMsg: 'No steps found in the zap route.',
+          };
+        }
+      }
+
+      const result = this.executeZap(steps, chainId, signer);
+      return result;
+    } catch (error: any) {
+      console.log({ error });
+      return handleViemTransactionError({ error });
+    }
+  };
+
+  public static executeZap = async (steps: ZapStep[], chainId: number, signer: Signer | WalletClient): Promise<DZapTransactionResponse> => {
+    let txnHash: HexString | undefined;
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      if (step.action === zapStepAction.execute) {
+        const result = await ZapTxnHandler.execute({ chainId, txnData: step.data as ZapEvmTxnDetails, signer });
+        if (result.status !== TxnStatus.success) {
+          return result;
+        }
+        txnHash = result.txnHash as HexString;
+      }
+    }
+    return {
+      status: TxnStatus.success,
+      code: StatusCodes.Success,
+      txnHash,
+    };
   };
 }
 

--- a/src/transactionHandlers/zap.ts
+++ b/src/transactionHandlers/zap.ts
@@ -112,7 +112,7 @@ class ZapTxnHandler {
     steps,
     signer,
   }: {
-    request: ZapBuildTxnRequest;
+    request: ZapBuildTxnRequest | ZapBundleRequest;
     steps?: ZapStep[];
     signer: Signer | WalletClient;
   }): Promise<
@@ -124,9 +124,10 @@ class ZapTxnHandler {
     | DZapTransactionResponse
   > => {
     try {
-      const { srcChainId: chainId } = request;
+      const chainId = 'srcChainId' in request ? request.srcChainId : request.actions[0].srcChainId;
       if (!steps || steps.length === 0) {
-        const route: ZapBuildTxnResponse = (await fetchZapBuildTxnData(request)).data;
+        const route: ZapBuildTxnResponse =
+          'actions' in request ? (await fetchZapBundleBuildTx(request)).data : (await fetchZapBuildTxnData(request)).data;
         steps = route.steps;
         if (!steps || steps.length === 0) {
           return {
@@ -136,77 +137,26 @@ class ZapTxnHandler {
           };
         }
       }
-      const result = this.executeZap(steps, chainId, signer);
-      return result;
+      let txnHash: HexString | undefined;
+      for (let i = 0; i < steps.length; i++) {
+        const step = steps[i];
+        if (step.action === zapStepAction.execute) {
+          const result = await ZapTxnHandler.execute({ chainId, txnData: step.data as ZapEvmTxnDetails, signer });
+          if (result.status !== TxnStatus.success) {
+            return result;
+          }
+          txnHash = result.txnHash as HexString;
+        }
+      }
+      return {
+        status: TxnStatus.success,
+        code: StatusCodes.Success,
+        txnHash,
+      };
     } catch (error: any) {
       console.log({ error });
       return handleViemTransactionError({ error });
     }
-  };
-
-  public static zapBundle = async ({
-    request,
-    steps,
-    signer,
-  }: {
-    request: ZapBundleRequest;
-    steps?: ZapStep[];
-    signer: Signer | WalletClient;
-  }): Promise<
-    | {
-        status: TxnStatus.success;
-        code: StatusCodes | number;
-        txnHash: HexString;
-      }
-    | DZapTransactionResponse
-  > => {
-    try {
-      const chainId = request.actions[0].srcChainId;
-
-      if (!chainId) {
-        return {
-          status: TxnStatus.error,
-          code: StatusCodes.Error,
-          errorMsg: 'Source chain ID is required.',
-        };
-      }
-      if (!steps || steps.length === 0) {
-        const route: ZapBuildTxnResponse = (await fetchZapBundleBuildTx(request)).data;
-        steps = route.steps;
-        if (!steps || steps.length === 0) {
-          return {
-            status: TxnStatus.error,
-            code: StatusCodes.FunctionNotFound,
-            errorMsg: 'No steps found in the zap route.',
-          };
-        }
-      }
-
-      const result = this.executeZap(steps, chainId, signer);
-      return result;
-    } catch (error: any) {
-      console.log({ error });
-      return handleViemTransactionError({ error });
-    }
-  };
-
-  public static executeZap = async (steps: ZapStep[], chainId: number, signer: Signer | WalletClient): Promise<DZapTransactionResponse> => {
-    let txnHash: HexString | undefined;
-    for (let i = 0; i < steps.length; i++) {
-      const step = steps[i];
-      if (step.action === zapStepAction.execute) {
-        const result = await ZapTxnHandler.execute({ chainId, txnData: step.data as ZapEvmTxnDetails, signer });
-        if (result.status !== TxnStatus.success) {
-          return result;
-        }
-        txnHash = result.txnHash as HexString;
-      }
-    }
-    return {
-      status: TxnStatus.success,
-      code: StatusCodes.Success,
-      txnHash,
-    };
   };
 }
 

--- a/src/types/zap/bundle.ts
+++ b/src/types/zap/bundle.ts
@@ -1,0 +1,31 @@
+import { ZapIntegratorConfig, ZapRouteRequestPoolDetails, ZapRouteRequestPositionDetails } from './build';
+import { ZapPathAction } from './path';
+
+export type ZapBundleSrcToken = {
+  address: string;
+  amount?: string;
+};
+
+export type ZapBundleAction = {
+  action: ZapPathAction;
+  srcToken: ZapBundleSrcToken | ZapBundleSrcToken[];
+  srcChainId: number;
+  destToken?: string;
+  destChainId?: number;
+  positionDetails?: ZapRouteRequestPositionDetails;
+  poolDetails?: ZapRouteRequestPoolDetails;
+  protocol?: string;
+};
+
+export type ZapBundleRequest = {
+  actions: ZapBundleAction[];
+  account: string;
+  recipient: string;
+  refundee: string;
+  slippage: number;
+  quotesOnly?: boolean;
+  estimateGas?: boolean;
+  integrator?: ZapIntegratorConfig;
+  allowedDexes?: string[];
+  allowedBridges?: string[];
+};

--- a/src/types/zap/index.ts
+++ b/src/types/zap/index.ts
@@ -27,6 +27,7 @@ export type ZapUnderlyingTokenWithAmount = ZapUnderlyingToken & {
 };
 
 export * from './build';
+export * from './bundle';
 export * from './path';
 export * from './pool';
 export * from './position';

--- a/src/zap/constants/path.ts
+++ b/src/zap/constants/path.ts
@@ -5,4 +5,6 @@ export const zapPathAction = {
   withdraw: 'withdraw',
   stake: 'stake',
   unstake: 'unstake',
+  increase: 'increase',
+  harvest: 'harvest',
 } as const;

--- a/src/zap/constants/urls.ts
+++ b/src/zap/constants/urls.ts
@@ -10,4 +10,8 @@ export const ZAP_ENDPOINTS = {
   buildTx: '/buildTx',
   quote: '/quote',
   broadcast: '/broadcast',
+  bundle: {
+    quote: '/bundle/quote',
+    buildTx: '/bundle/buildTx',
+  },
 };


### PR DESCRIPTION
Bundle zap flow (new capability)

- Adds bundle zap request typing and exports (new `src/types/zap/bundle.ts`, updates in zap type index exports).
Extends API/client surface to support bundle quote + build endpoints.
Adds client methods for bundle operations:
`getZapBundleQuote(...)`
`buildZapBundleTx(...)`

- Updates zap transaction handling logic to support portfolio-style multi-action execution flows (e.g. claim fees, compound, increase/decrease/reposition paths).
Route/constants integration

- Adds/updates zap route/path constants so bundle endpoints are reachable through existing SDK abstractions.
Updates URL/path mappings used by zap API calls.

